### PR TITLE
provisionally secured event

### DIFF
--- a/randol_pizzajob/server/sv_pizzajob.lua
+++ b/randol_pizzajob/server/sv_pizzajob.lua
@@ -1,15 +1,30 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
+local checkForJobNumber = true -- This setting allows tracking how many jobs the player has completed. 
+local maximumJobs = 30 -- Maximum ammount based of number of JobLocations | For Security purposes keep in server-side
+local timeoutTime = 60 -- Time in seconds how long the player will be in timeout
+local inTimeout = {}
+
 RegisterServerEvent('randol_pizzajob:server:Payment', function(jobsDone)
-	local src = source
+    local src = source
     local payment = Config.Payment * jobsDone
-	local Player = QBCore.Functions.GetPlayer(source)
+    local Player = QBCore.Functions.GetPlayer(source)
+
+    if not src then return end
+    if #(GetEntityCoords(GetPlayerPed(src)) - vector3(Config.BossCoords.x, Config.BossCoords.y, Config.BossCoords.z)) < 10.0 then
     jobsDone = tonumber(jobsDone)
-    if jobsDone > 0 then
-        Player.Functions.AddMoney("cash", payment)
-        TriggerClientEvent("QBCore:Notify", source, "You received $"..payment, "success")
+
+    if inTimeout[src] then DropPlayer(src, 'Exploiting - Was in timeout') return end
+    if checkForJobNumber == true then
+        if jobsDone > 30 then DropPlayer(src, 'Exploiting') return end -- You can replace DropPlayer with your ban resource exports
     end
+    
+    Player.Functions.AddMoney("cash", payment)
+    TriggerClientEvent("QBCore:Notify", source, "You received $"..payment, "success")
+    inTimeout[src] = true
+
+    SetTimeout(timeoutTime * 1000, function()
+        inTimeout[src] = nil
+    end)
 end)
-
-
 

--- a/randol_pizzajob/server/sv_pizzajob.lua
+++ b/randol_pizzajob/server/sv_pizzajob.lua
@@ -15,7 +15,7 @@ RegisterServerEvent('randol_pizzajob:server:Payment', function(jobsDone)
     jobsDone = tonumber(jobsDone)
 
     if inTimeout[src] then DropPlayer(src, 'Exploiting - Was in timeout') return end
-    if checkForJobNumber == true then
+    if checkForJobNumber then
         if jobsDone > 30 then DropPlayer(src, 'Exploiting') return end -- You can replace DropPlayer with your ban resource exports
     end
     

--- a/randol_pizzajob/server/sv_pizzajob.lua
+++ b/randol_pizzajob/server/sv_pizzajob.lua
@@ -16,7 +16,7 @@ RegisterServerEvent('randol_pizzajob:server:Payment', function(jobsDone)
 
     if inTimeout[src] then DropPlayer(src, 'Exploiting - Was in timeout') return end
     if checkForJobNumber then
-        if jobsDone > 30 then DropPlayer(src, 'Exploiting') return end -- You can replace DropPlayer with your ban resource exports
+        if jobsDone > maximumJobs then DropPlayer(src, 'Exploiting') return end -- You can replace DropPlayer with your ban resource exports
     end
     
     Player.Functions.AddMoney("cash", payment)


### PR DESCRIPTION
I tried to secure the server event, but the script is built on the client-side, and therefore nothing much can be done. The only thing to do is to rewrite the script on the server-side so that the security is greater.

**checkForJobNumber** - true / false, option to turn off tracking of how many jobs the player has done
 **maximumJobs** - Numerical value of how many jobs the player can perform at most 
**timeoutTime** - numerical value in seconds, indicates the time when timeOut will be reset

timeout causes that if the player used the executor to invoke the event 2 times in a row or within a time limit when it is unrealistic to complete the next job, he would be banned